### PR TITLE
added faster functions for reading c-strings that utilize io::Seek

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -132,7 +132,7 @@ impl<W> WritePrimitives for W where W: io::Write {}
 /// Provides methods for reading strings of various encodings.
 pub trait ReadStrings: io::Read {
     /// Reads a UTF-8 encoded string from the underlying reader with a given length (in bytes).
-    fn read_string_utf8(
+    fn read_str_utf8(
         &mut self,
         len: usize,
     ) -> io::Result<Result<String, std::string::FromUtf8Error>> {
@@ -145,7 +145,7 @@ pub trait ReadStrings: io::Read {
 
     /// Reads a UTF-8 encoded string from the underlying reader with a given length (in bytes).
     /// The validity of the UTF-8 is not checked, therefore this is unsafe.
-    unsafe fn read_string_utf8_unchecked(&mut self, len: usize) -> io::Result<String> {
+    unsafe fn read_str_utf8_unchecked(&mut self, len: usize) -> io::Result<String> {
         Ok(String::from_utf8_unchecked({
             let mut buf = vec![0u8; len];
             self.read_exact(&mut buf[..])?;
@@ -157,7 +157,7 @@ pub trait ReadStrings: io::Read {
     /// If any invalid UTF-8 sequences are present,
     /// they are replaced with U+FFFD REPLACEMENT CHARACTER,
     /// which looks like this: �
-    fn read_string_utf8_lossy(&mut self, len: usize) -> io::Result<String> {
+    fn read_str_utf8_lossy(&mut self, len: usize) -> io::Result<String> {
         let mut buf = vec![0u8; len];
         self.read_exact(&mut buf[..])?;
         Ok(String::from_utf8_lossy(&buf).into_owned())
@@ -169,7 +169,7 @@ pub trait ReadStrings: io::Read {
     /// # Panics
     /// Panics if `len * 2` overflows usize.
     #[inline(always)]
-    fn read_string_utf16(
+    fn read_str_utf16(
         &mut self,
         len: usize,
     ) -> io::Result<Result<String, std::string::FromUtf16Error>> {
@@ -189,7 +189,7 @@ pub trait ReadStrings: io::Read {
     /// # Panics
     /// Panics if `len * 2` overflows usize.
     #[inline(always)]
-    fn read_string_utf16_lossy(&mut self, len: usize) -> io::Result<String> {
+    fn read_str_utf16_lossy(&mut self, len: usize) -> io::Result<String> {
         let mut buf = vec![0u8; len.checked_mul(2).expect("input length overflows usize")];
         self.read_exact(&mut buf[..])?;
         Ok(String::from_utf16_lossy(unsafe {
@@ -205,7 +205,7 @@ pub trait ReadStrings: io::Read {
     /// It will return io::ErrorKind::UnexpectedEof.
     ///
     /// Providing a `size_hint` will speed up the reading slightly, especially on larger strings.
-    fn read_cstring_utf8(
+    fn read_cstr_utf8(
         &mut self,
         max: Option<usize>,
         size_hint: Option<usize>,
@@ -241,7 +241,7 @@ pub trait ReadStrings: io::Read {
     /// It will return io::ErrorKind::UnexpectedEof.
     ///
     /// Providing a `size_hint` will speed up the reading slightly, especially on larger strings.
-    fn read_cstring_utf8_lossy(
+    fn read_cstr_utf8_lossy(
         &mut self,
         max: Option<usize>,
         size_hint: Option<usize>,

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -100,51 +100,72 @@ fn read_write_strings() {
     let test_cstring_unterminated = b"Hello, world!"; // no null
 
     // reading
-    let mut reader = Cursor::new(test_utf8.as_bytes());
     assert_eq!(
         test_utf8,
-        reader.read_str_utf8(test_utf8.len()).unwrap().unwrap().as_str()
+        Cursor::new(test_utf8.as_bytes())
+            .read_str_utf8(test_utf8.len())
+            .unwrap()
+            .unwrap()
+            .as_str()
     );
 
-    let mut reader = Cursor::new(test_utf8_invalid);
     assert!(
-        reader
+        Cursor::new(test_utf8_invalid)
             .read_str_utf8(test_utf8_invalid.len())
             .unwrap()
             .is_err()
     );
-    reader.set_position(0);
     assert_eq!(
         "Hello, �world!",
-        reader.read_str_utf8_lossy(test_utf8_invalid.len()).unwrap().as_str()
+        Cursor::new(test_utf8_invalid)
+            .read_str_utf8_lossy(test_utf8_invalid.len())
+            .unwrap()
+            .as_str()
     );
 
     let utf16_bytes = test_utf8
         .encode_utf16()
         .collect::<Vec<_>>()
         .into_boxed_slice();
-    let mut reader = Cursor::new(unsafe {
-        slice::from_raw_parts(utf16_bytes.as_ptr() as *const u8, utf16_bytes.len() * 2)
-    });
     assert_eq!(
         test_utf8,
-        reader.read_str_utf16(utf16_bytes.len()).unwrap().unwrap().as_str()
+        Cursor::new(unsafe {
+            slice::from_raw_parts(utf16_bytes.as_ptr() as *const u8, utf16_bytes.len() * 2)
+        })
+        .read_str_utf16(utf16_bytes.len())
+        .unwrap()
+        .unwrap()
+        .as_str()
     );
 
-    let mut reader = Cursor::new(test_cstring);
     assert_eq!(
         "Hello, world!",
-        &*(reader.read_cstr_utf8(None, None).unwrap().unwrap())
+        Cursor::new(test_cstring)
+            .read_cstr_utf8(None, None)
+            .unwrap()
+            .unwrap()
+            .as_str()
     );
-    reader.set_position(0);
-    assert!(reader.read_cstr_utf8(Some(4), None).is_err()); // max chars = 4, no null found
+    assert!(
+        Cursor::new(test_cstring)
+            .read_cstr_utf8(Some(4), None)
+            .is_err()
+    ); // max chars = 4, no null found
+    assert!(
+        Cursor::new(test_cstring_unterminated)
+            .read_cstr_utf8(None, None)
+            .is_err()
+    );
 
-    let mut reader = Cursor::new(test_cstring_unterminated);
-    assert!(reader.read_cstr_utf8(None, None).is_err());
-
-    let mut reader = Cursor::new(test_cstring);
     // [..13] trims the null here for fair comparison
-    assert_eq!(&test_cstring[..13], reader.read_cstr_utf8_fast(None).unwrap().unwrap().as_bytes());
+    assert_eq!(
+        &test_cstring[..13],
+        Cursor::new(test_cstring)
+            .read_cstr_utf8_fast(None)
+            .unwrap()
+            .unwrap()
+            .as_bytes()
+    );
 
     // writing
     // ...... oh that doesn't exist yet!

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -101,26 +101,50 @@ fn read_write_strings() {
 
     // reading
     let mut reader = Cursor::new(test_utf8.as_bytes());
-    assert_eq!(test_utf8, &*(reader.read_str_utf8(test_utf8.len()).unwrap().unwrap()));
+    assert_eq!(
+        test_utf8,
+        reader.read_str_utf8(test_utf8.len()).unwrap().unwrap().as_str()
+    );
 
     let mut reader = Cursor::new(test_utf8_invalid);
-    assert!(reader.read_str_utf8(test_utf8_invalid.len()).unwrap().is_err());
+    assert!(
+        reader
+            .read_str_utf8(test_utf8_invalid.len())
+            .unwrap()
+            .is_err()
+    );
     reader.set_position(0);
-    assert_eq!("Hello, �world!", &*(reader.read_str_utf8_lossy(test_utf8_invalid.len()).unwrap()));
+    assert_eq!(
+        "Hello, �world!",
+        reader.read_str_utf8_lossy(test_utf8_invalid.len()).unwrap().as_str()
+    );
 
-    let utf16_bytes = test_utf8.encode_utf16().collect::<Vec<_>>().into_boxed_slice();
+    let utf16_bytes = test_utf8
+        .encode_utf16()
+        .collect::<Vec<_>>()
+        .into_boxed_slice();
     let mut reader = Cursor::new(unsafe {
         slice::from_raw_parts(utf16_bytes.as_ptr() as *const u8, utf16_bytes.len() * 2)
     });
-    assert_eq!(test_utf8, &*(reader.read_str_utf16(utf16_bytes.len()).unwrap().unwrap()));
+    assert_eq!(
+        test_utf8,
+        reader.read_str_utf16(utf16_bytes.len()).unwrap().unwrap().as_str()
+    );
 
     let mut reader = Cursor::new(test_cstring);
-    assert_eq!("Hello, world!", &*(reader.read_cstr_utf8(None, None).unwrap().unwrap()));
+    assert_eq!(
+        "Hello, world!",
+        &*(reader.read_cstr_utf8(None, None).unwrap().unwrap())
+    );
     reader.set_position(0);
     assert!(reader.read_cstr_utf8(Some(4), None).is_err()); // max chars = 4, no null found
-    
+
     let mut reader = Cursor::new(test_cstring_unterminated);
     assert!(reader.read_cstr_utf8(None, None).is_err());
+
+    let mut reader = Cursor::new(test_cstring);
+    // [..13] trims the null here for fair comparison
+    assert_eq!(&test_cstring[..13], reader.read_cstr_utf8_fast(None).unwrap().unwrap().as_bytes());
 
     // writing
     // ...... oh that doesn't exist yet!

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -101,26 +101,26 @@ fn read_write_strings() {
 
     // reading
     let mut reader = Cursor::new(test_utf8.as_bytes());
-    assert_eq!(test_utf8, &*(reader.read_string_utf8(test_utf8.len()).unwrap().unwrap()));
+    assert_eq!(test_utf8, &*(reader.read_str_utf8(test_utf8.len()).unwrap().unwrap()));
 
     let mut reader = Cursor::new(test_utf8_invalid);
-    assert!(reader.read_string_utf8(test_utf8_invalid.len()).unwrap().is_err());
+    assert!(reader.read_str_utf8(test_utf8_invalid.len()).unwrap().is_err());
     reader.set_position(0);
-    assert_eq!("Hello, �world!", &*(reader.read_string_utf8_lossy(test_utf8_invalid.len()).unwrap()));
+    assert_eq!("Hello, �world!", &*(reader.read_str_utf8_lossy(test_utf8_invalid.len()).unwrap()));
 
     let utf16_bytes = test_utf8.encode_utf16().collect::<Vec<_>>().into_boxed_slice();
     let mut reader = Cursor::new(unsafe {
         slice::from_raw_parts(utf16_bytes.as_ptr() as *const u8, utf16_bytes.len() * 2)
     });
-    assert_eq!(test_utf8, &*(reader.read_string_utf16(utf16_bytes.len()).unwrap().unwrap()));
+    assert_eq!(test_utf8, &*(reader.read_str_utf16(utf16_bytes.len()).unwrap().unwrap()));
 
     let mut reader = Cursor::new(test_cstring);
-    assert_eq!("Hello, world!", &*(reader.read_cstring_utf8(None, None).unwrap().unwrap()));
+    assert_eq!("Hello, world!", &*(reader.read_cstr_utf8(None, None).unwrap().unwrap()));
     reader.set_position(0);
-    assert!(reader.read_cstring_utf8(Some(4), None).is_err()); // max chars = 4, no null found
+    assert!(reader.read_cstr_utf8(Some(4), None).is_err()); // max chars = 4, no null found
     
     let mut reader = Cursor::new(test_cstring_unterminated);
-    assert!(reader.read_cstring_utf8(None, None).is_err());
+    assert!(reader.read_cstr_utf8(None, None).is_err());
 
     // writing
     // ...... oh that doesn't exist yet!


### PR DESCRIPTION
- new function read_cstr_utf8_fast
- new function read_cstr_utf8_lossy_fast

Always preferred when `self` can `io::Seek`.